### PR TITLE
feat: warmup & Threadpool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 run_server:
-	bentoml serve vton_daflow:latest --port 8501
+	bentoml serve vton_daflow:latest --port 8502
 
 run_client:
 	python3 -m streamlit run service/front-end/homepage.py --server.port 30003 --server.fileWatcherType none
+
+run_server_warmup:
+	python service/back-end/app/warmup_server.py
 
 run_save_model:
 	python service/back-end/app/save_model.py
@@ -15,4 +18,4 @@ run_apt_install:
 run_build:
 	bentoml build -f service/back-end/app/bentofile.yaml service/back-end/app
 
-run_app: run_server run_client
+run_app: run_server run_client run_server_warmup

--- a/README.md
+++ b/README.md
@@ -70,23 +70,13 @@
 4. `make run_checkpoints_download`
 5. `python service/back-end/app/save_model.py --daflow-path {path} --openpose-path {path} --parser-path {path} (checkpoint model path)`
 6. `make run_build`
-7. `make -j 2 run_app`
+7. `make -j 3 run_app`
 
 
 ## If your model saved in bentoml.models and modifying service content
 
 1. `make run_build`
 2. `make -j 2 run_app`
-
-## Checkpoint
-
-[DAFlow_256_192_checkpoint](https://www.dropbox.com/s/6kogpt90zgw7wxp/100_mod_all_256.pt)
-
-[DAFlow_512_384_checkpoint](https://www.dropbox.com/s/kg9e0m6sr2j3fp0/003_allbody_512_upscale_low_lr.pt)
-
-[Openpose](https://www.dropbox.com/sh/7xbup2qsn7vvjxo/AABWFksdlgOMXR_r5v3RwKRYa?dl=0)
-
-[Human_parser](https://drive.google.com/u/0/uc?id=1ruJg4lqR_jgQPj-9K0PP-L2vJERYOxLP&export=download)
 
 ## Reference
 

--- a/service/back-end/app/modules/preprocess.py
+++ b/service/back-end/app/modules/preprocess.py
@@ -20,15 +20,13 @@ def cloth_removed_background(interface, image):
 
 def get_openpose(model, human):
     openpose = Openpose(model)
-    numpy_image=np.array(human)  
-    human_bgr=cv2.cvtColor(numpy_image, cv2.COLOR_RGB2BGR)
-    skeleton, keypoint = openpose.get_bodypose(human_bgr)
+    human_bgr=cv2.cvtColor(human, cv2.COLOR_RGB2BGR)
+    openpose_result = openpose.get_bodypose(human_bgr)
     
-    return skeleton, keypoint   # skeleton은 image, keypoint는 json
+    return openpose_result   # skeleton은 image, keypoint는 json
 
 def get_human_parse(model, human):
-    human_parse = np.array(human)
-    parser_map = get_parser_map(model, human_parse)
+    parser_map = get_parser_map(model, human)
     
     return parser_map
 

--- a/service/back-end/app/service.py
+++ b/service/back-end/app/service.py
@@ -10,8 +10,7 @@ from torchvision import transforms
 from modules.carvekit_custom.high import HiInterface
 import os
 import json
-
-from torchvision.utils import save_image
+from concurrent.futures import ThreadPoolExecutor
 
 cudnn.benchmark = True
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -31,7 +30,8 @@ fba_runner = fba_model.to_runner()
 parser_model = bentoml.models.get('human_parser:latest')
 parser_runner = parser_model.to_runner()
 
-svc = bentoml.Service('vton_daflow', runners=[vton_runner, openpose_runner, tracer_runner, fba_runner, parser_runner])
+svc = bentoml.Service('vton_daflow', runners=[vton_runner, openpose_runner, tracer_runner, fba_runner, parser_runner],
+                      models=[vton_model, openpose_model, tracer_model, fba_model, parser_model])
 
 interface = HiInterface(object_type="object",  # Can be "object" or "hairs-like".
                             batch_size_seg=1,
@@ -62,8 +62,6 @@ async def predict_from_cloth(cloth, avatar_path):
 
     tryon_result = vton_runner.run(ref_input, cloth_img, img_agnostic).detach()
 
-    save_image(tryon_result, '/opt/ml/final/result.jpg', nrow=1, normalize=True, range=(-1,1))
-
     imgs = ((tryon_result.squeeze().permute(1, 2, 0).cpu().numpy()*0.5+0.5)*255).astype(np.uint8)
     transf = transforms.ToPILImage()
     imgs = transf(imgs)
@@ -73,18 +71,28 @@ async def predict_from_cloth(cloth, avatar_path):
 save_dir = '/opt/ml/input/final-project-level3-cv-12/service/back-end/app/result_sample'
 os.makedirs(save_dir, exist_ok=True)
 
-@svc.api(input=Multipart(part=Text(), cloth=Image(), human=Image()), output=Image(), route='/all-tryon')
-async def predict_from_cloth_human(part, cloth, human):
-    cloth = preprocess.cloth_removed_background(interface, cloth)
-    cloth_img = _transform_image(cloth).to(device)
-    test = ((cloth_img.squeeze().permute(1, 2, 0).cpu().numpy()*0.5+0.5)*255).astype(np.uint8)
-    pImage.fromarray(test).save(f'{save_dir}/cloth.png', 'png')
+from multiprocessing import Pool
+import time
 
-    skeleton, keypoint = preprocess.get_openpose(openpose_runner, human)
-    parser_map = preprocess.get_human_parse(parser_runner, human)
+@svc.api(input=Multipart(part=Text(), cloth=Image(), human=Image()), output=Image(), route='/all-tryon')
+def predict_from_cloth_human(part, cloth, human):
+    human = np.array(human)
+
+    with ThreadPoolExecutor(3) as executor:
+        openpose = executor.submit(preprocess.get_openpose, openpose_runner, human)
+        cloth = executor.submit(preprocess.cloth_removed_background, interface, cloth)
+        parser_map = executor.submit(preprocess.get_human_parse, parser_runner, human)
+    
+    skeleton, keypoint = openpose.result()
+    cloth = cloth.result()
+    parser_map = parser_map.result()
+    
+    cloth_img = _transform_image(cloth).to(device)
+    cloth_img_result = ((cloth_img.squeeze().permute(1, 2, 0).cpu().numpy()*0.5+0.5)*255).astype(np.uint8)
+    pImage.fromarray(cloth_img_result).save(f'{save_dir}/cloth.png', 'png')
+
     parser_map.save(f'{save_dir}/parser_map.png', 'png')
 
-    print(keypoint)
     with open(f'{save_dir}/keypoints.json', 'w') as f:
         json.dump(keypoint, f)
     

--- a/service/back-end/app/warmup_server.py
+++ b/service/back-end/app/warmup_server.py
@@ -1,0 +1,35 @@
+import requests
+from PIL import Image
+import io
+import time
+import os
+def run_server():
+    print(os.getcwd())
+    time.sleep(5)
+    print("warmup server start.")
+    
+    cloth = Image.open('service/back-end/warmup_sample/cloth.jpg')
+    human = Image.open('service/back-end/warmup_sample/human.jpg')
+
+    clothByteArr = io.BytesIO()
+    cloth.save(clothByteArr, format=cloth.format)
+    clothByteArr = clothByteArr.getvalue()
+    
+    humanByteArr = io.BytesIO()
+    human.save(humanByteArr, format=human.format)
+    humanByteArr = humanByteArr.getvalue()
+    
+    files = [
+        ('part', ('dresses')),
+        ("cloth", ('dummy', clothByteArr, 'image/jpeg')),
+        ("human", ('dummy', humanByteArr, 'image/jpeg'))
+    ]
+
+    response = requests.post("http://0.0.0.0:8502/all-tryon", files=files)
+    
+    if response.status_code == 200:
+        print("completed warmup.")
+    else:
+        print(f"{response.status_code} error occurred while warmup.")
+    
+run_server()


### PR DESCRIPTION
## Summary
1. 서버 구동 시 첫 inference 단계에서 전처리 및 daflow 모델을 메모리에 적재하는 시간으로 인해 느린 응답 시간을 확인
2. cloth, human 업로드하는 api 호출 시 각 전처리 모듈이 순차적으로 실행됨

## Describe your changes
1. back-end 서버 구동 시 warmup request를 통해 사용 예정인 모델들을 미리 메모리에 적재
2. cloth, human 업로드하는 api 호출 시 openpose, carvekit, human_parser 모듈에 Threadpool을 적용해 시간 시간 단축

## Issue number and link
https://github.com/boostcampaitech4lv23cv2/final-project-level3-cv-12/issues/45#issue-1571243842